### PR TITLE
Fix location of externalsWhitelist option

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -44,10 +44,5 @@ export default {
     normal: 'inline', // Or `extract`
     vue: 'inline', // Or `extract`
   },
-
-  /**
-   * Add some packages to webpack-node-externals
-   */
-  externalsWhitelist: [],
 };
 ```

--- a/docs/reference/server-config.md
+++ b/docs/reference/server-config.md
@@ -80,5 +80,10 @@ export default {
    */
   watch: ['server.config.js'],
   watchIgnore: ['dist/**/*'],
+
+  /**
+   * Add some packages to webpack-node-externals
+   */
+  externalsWhitelist: [],
 };
 ```


### PR DESCRIPTION
According to https://github.com/universal-vue/uvue/blob/b41f56401894b6f450b809a6040c3296dccf0c63/packages/%40uvue/vue-cli-plugin-ssr/webpack/server.js#L5, the `externalsWhitelist` option is retrieved from the server configuration, not a default one.