### PR TITLE
Fix order of arguments

### DIFF
--- a/docs/plugins/uvue.md
+++ b/docs/plugins/uvue.md
@@ -97,12 +97,12 @@ export default {
   },
 
   // When an error is thrown during a routeResolve() call
-  async routeError(error, context) {
+  async routeError(context, error) {
     //...
   },
 
   // When a error is thrown during plugins hooks
-  catchError(error, context) {
+  catchError(context, error) {
     //...
   },
 


### PR DESCRIPTION
As seen in e.g. [errorHandler plugin](https://github.com/universal-vue/uvue/blob/c1e3365ddaa05ace6bf86b07268d7d8b8537b722/packages/%40uvue/core/plugins/errorHandler.js#L74), the order of imports is exactly the opposite as shown in the docs. This inconsistency could lead to some serious misunderstandings and long hours of debugging.